### PR TITLE
Fix security and reliability bugs (issues #1–#9)

### DIFF
--- a/apps/example-tool-api/src/agentpi/stores.ts
+++ b/apps/example-tool-api/src/agentpi/stores.ts
@@ -10,7 +10,14 @@ export class PrismaJtiStore implements JtiStore {
   }
 
   async add(jti: string, expiresAt: Date): Promise<void> {
-    await this.prisma.usedJti.create({ data: { jti, expiresAt } });
+    try {
+      await this.prisma.usedJti.create({ data: { jti, expiresAt } });
+    } catch (error: any) {
+      if (error?.code === 'P2002') {
+        throw new Error('JTI already used');
+      }
+      throw error;
+    }
   }
 }
 

--- a/apps/example-tool-api/src/main.ts
+++ b/apps/example-tool-api/src/main.ts
@@ -8,12 +8,17 @@ import { resolve } from 'path';
 dotenv.config({ path: resolve(__dirname, '../../../.env') });
 
 async function bootstrap() {
-  const app = await NestFactory.create<NestFastifyApplication>(
-    AppModule,
-    new FastifyAdapter(),
-  );
-  const port = process.env.TOOL_PORT || 4020;
-  await app.listen(port, '0.0.0.0');
-  console.log(`Example Tool API listening on :${port}`);
+  try {
+    const app = await NestFactory.create<NestFastifyApplication>(
+      AppModule,
+      new FastifyAdapter(),
+    );
+    const port = process.env.TOOL_PORT || 4020;
+    await app.listen(port, '0.0.0.0');
+    console.log(`Example Tool API listening on :${port}`);
+  } catch (error) {
+    console.error('Failed to start Example Tool API:', error);
+    process.exit(1);
+  }
 }
 bootstrap();

--- a/apps/service/src/grants/grants.service.ts
+++ b/apps/service/src/grants/grants.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException, ForbiddenException } from '@nestjs/common';
+import { Injectable, UnauthorizedException, ForbiddenException, BadRequestException } from '@nestjs/common';
 import { KeysService } from '../keys/keys.service';
 import { v4 as uuid } from 'uuid';
 import {
@@ -25,6 +25,18 @@ export class GrantsService {
   async issueGrant(body: ConnectGrantRequest): Promise<ConnectGrantResponse> {
     if (body.tool_id !== this.toolId) {
       throw new ForbiddenException(`Unknown tool_id: ${body.tool_id}`);
+    }
+    if (!Array.isArray(body.requested_scopes)) {
+      throw new BadRequestException('requested_scopes is required and must be an array');
+    }
+    if (!body.requested_limits || typeof body.requested_limits !== 'object') {
+      throw new BadRequestException('requested_limits is required and must be an object');
+    }
+    if (!body.workspace || typeof body.workspace !== 'object') {
+      throw new BadRequestException('workspace is required and must be an object');
+    }
+    if (!body.nonce || typeof body.nonce !== 'string') {
+      throw new BadRequestException('nonce is required and must be a string');
     }
 
     const jti = uuid();

--- a/apps/service/src/main.ts
+++ b/apps/service/src/main.ts
@@ -8,12 +8,17 @@ import { resolve } from 'path';
 dotenv.config({ path: resolve(__dirname, '../../../.env') });
 
 async function bootstrap() {
-  const app = await NestFactory.create<NestFastifyApplication>(
-    AppModule,
-    new FastifyAdapter(),
-  );
-  const port = process.env.AGENTPI_PORT || 4010;
-  await app.listen(port, '0.0.0.0');
-  console.log(`AgentPI service listening on :${port}`);
+  try {
+    const app = await NestFactory.create<NestFastifyApplication>(
+      AppModule,
+      new FastifyAdapter(),
+    );
+    const port = process.env.AGENTPI_PORT || 4010;
+    await app.listen(port, '0.0.0.0');
+    console.log(`AgentPI service listening on :${port}`);
+  } catch (error) {
+    console.error('Failed to start AgentPI service:', error);
+    process.exit(1);
+  }
 }
 bootstrap();

--- a/packages/sdk/src/prisma.ts
+++ b/packages/sdk/src/prisma.ts
@@ -27,6 +27,10 @@ interface PrismaLike {
         scopes: string[];
       };
     }): Promise<unknown>;
+    updateMany(args: {
+      where: { toolAgentId: string; revokedAt: null };
+      data: { revokedAt: Date };
+    }): Promise<unknown>;
   };
 }
 
@@ -59,6 +63,11 @@ export function prismaProvision(prisma: PrismaLike) {
       },
       create: { workspaceId: workspace.id, agentpiAgentId: ctx.agentId, status: 'active' },
       update: { status: 'active' },
+    });
+
+    await prisma.toolApiKey.updateMany({
+      where: { toolAgentId: agent.id, revokedAt: null },
+      data: { revokedAt: new Date() },
     });
 
     const { full, prefix, secret } = generateApiKey();

--- a/packages/sdk/src/stores.ts
+++ b/packages/sdk/src/stores.ts
@@ -14,6 +14,10 @@ export class MemoryJtiStore implements JtiStore {
   }
 
   async add(jti: string, expiresAt: Date): Promise<void> {
+    const existing = this.used.get(jti);
+    if (existing !== undefined && Date.now() <= existing) {
+      throw new Error('JTI already used');
+    }
     this.used.set(jti, expiresAt.getTime());
   }
 }


### PR DESCRIPTION
## Summary

Fixes 8 bugs reported across issues #1–#9 (9 files changed, all build clean):

- **#1 — Atomic key writes**: `KeysService` now writes key files to `.tmp` then renames, and detects partial state on startup instead of silently rotating signing keys.
- **#2 — JTI race condition**: `jtiStore.add()` is now called as an atomic guard *before* provisioning (not after), closing the TOCTOU window that allowed concurrent replay.
- **#3 — API key accumulation**: `prismaProvision` revokes existing active keys before creating a new one, preventing unbounded key growth and scope-escalation on reconnect.
- **#4 — Missing `exp` validation**: `verifyConnectGrant` now rejects JWTs without a numeric `exp` claim, preventing `NaN` from breaking JTI tracking.
- **#5 — Malformed grant requests**: `GrantsService.issueGrant()` validates `requested_scopes`, `requested_limits`, `workspace`, and `nonce` at runtime before building the JWT.
- **#6 — Shared JWKS cache**: JWKS cache is now a `Map` keyed by URL so multiple tools in the same process verify against the correct key set.
- **#7 — Nonce in idempotency hash**: `nonce` is now included in the request hash so differing nonces properly trigger 409 conflicts.
- **#8 — Unhandled bootstrap**: Both `main.ts` entry points wrap `bootstrap()` in try-catch with `process.exit(1)`.
- **#9 — Retry returns 401**: Resolved by #2 — idempotency check now precedes the JTI guard, so legitimate retries return cached 200 responses.

Closes #1, closes #2, closes #3, closes #4, closes #5, closes #6, closes #7, closes #8, closes #9

## Test plan

- [x] `pnpm build` passes across all 5 workspace packages
- [ ] Run `pnpm dev` and `pnpm demo` to verify end-to-end connect flow
- [ ] Run `pnpm verify` conformance checks
- [ ] Verify partial key state detection: delete one key file, restart service, confirm error
- [ ] Verify concurrent JTI replay is blocked (two simultaneous requests with same JWT)
- [ ] Verify reconnect revokes old API keys (check DB after second connect)